### PR TITLE
Remove heuristics for finding whitebox; not generic!

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,30 +5,15 @@
 
 #' Check for WhiteboxTools Binary
 #'
-#' @param path Path to search for binary (if not found at standard locations)
-#' @param pattern Pattern to match for binary name
 #' @param silent logical. Print help on installation/setting binary path. Default `TRUE`.
 #' @seealso [wbt_exe_path()]
-#' @aliases find_whitebox_binary
 #' @return logical if WhiteboxTools Binary exists.
 #' @export
-check_whitebox_binary <- function(path = "~",
-                                  pattern = "whitebox_tools$|whitebox_tools.exe$",
-                                  silent = TRUE) {
+check_whitebox_binary <- function(silent = TRUE) {
 
   # look in standard locations
   exe_path <- wbt_exe_path(shell_quote = FALSE)
   res <- file.exists(exe_path)
-
-  if (!res) {
-    wbfind <- find_whitebox_binary(path = path, pattern = pattern, best = TRUE)
-    res <- file.exists(wbfind)
-    if (length(res) > 0 && res) {
-      wbt_init_from_path(wbfind)
-    } else {
-      res <- FALSE
-    }
-  }
 
   if (!res && !silent) {
     msg <- paste0(
@@ -51,24 +36,5 @@ check_whitebox_binary <- function(path = "~",
       "------------------------------------------------------------------------\n")
     message(msg)
   }
-  res
-}
-
-# @param best Use heuristics to select "best" WhiteboxTools (`TRUE` for use in `check_whitebox_binary()`, default `FALSE` for `find_whitebox_binary()`)
-find_whitebox_binary <- function(path = "~",
-                                 pattern = "whitebox_tools$|whitebox_tools.exe",
-                                 token_patterns = c("whitebox-tools","target","release","WBT"),
-                                 best = FALSE) {
-
-  res <- list.files(path = path,  pattern = pattern, recursive = TRUE, full.names = TRUE)
-
-  # TODO: this could probably be improved
-  if (best && length(res) > 1) {
-    .pickBestBinary <- function(s) {
-      which.max(apply(sapply(token_patterns, function(x) grepl(x, res), simplify = FALSE), 1, sum))
-    }
-    res <- res[.pickBestBinary(res)]
-  }
-
   res
 }

--- a/man/check_whitebox_binary.Rd
+++ b/man/check_whitebox_binary.Rd
@@ -2,20 +2,11 @@
 % Please edit documentation in R/zzz.R
 \name{check_whitebox_binary}
 \alias{check_whitebox_binary}
-\alias{find_whitebox_binary}
 \title{Check for WhiteboxTools Binary}
 \usage{
-check_whitebox_binary(
-  path = "~",
-  pattern = "whitebox_tools$|whitebox_tools.exe$",
-  silent = TRUE
-)
+check_whitebox_binary(silent = TRUE)
 }
 \arguments{
-\item{path}{Path to search for binary (if not found at standard locations)}
-
-\item{pattern}{Pattern to match for binary name}
-
 \item{silent}{logical. Print help on installation/setting binary path. Default `TRUE`.}
 }
 \value{


### PR DESCRIPTION
Resolves #40; the former "find whitebox" method was something I had tinkered with and was concerned at the time that it might not do what the user wants. 

Thanks to @bkielstr tested it and had various issues on windows and macos, thanks for reporting it! I didn't anticipate those specific problems, I was more concerned about it accidentally finding the wrong binary or one that didnt have permissions to execute!

Testing the latest using a snippet from the readme of https://github.com/bkielstr/hydroweight on my work computer (limited to WBT 1.4.0 for now, need newer version approved)

``` r
## Load libraries

Sys.setenv(R_WHITEBOX_EXE_PATH = 'C:/Program Files/UniversityofGeulphWhiteboxTools1.4.0_WKS/WBT/whitebox_tools.exe')

library(raster)
library(whitebox)
library(hydroweight)

## Import toy_dem from whitebox package
toy_file <- system.file("extdata", "DEM.tif", package = "whitebox")
toy_dem <- raster(x = toy_file, values = TRUE)
crs(toy_dem) <- "+init=epsg:3161"

## Generate hydroweight_dir as a temporary directory
hydroweight_dir <- tempdir()

## Write toy_dem to hydroweight_dir
writeRaster(
  x = toy_dem, filename = file.path(hydroweight_dir, "toy_dem.tif"),
  overwrite = TRUE
)

## Breach depressions to ensure continuous flow
wbt_breach_depressions(
  dem = file.path(hydroweight_dir, "toy_dem.tif"),
  output = file.path(hydroweight_dir, "toy_dem_breached.tif")
)
#> [1] "breach_depressions - Elapsed Time (excluding I/O): 0.10s"
```

