### PR TITLE
install_whitebox updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,7 @@ Suggests:
     rmarkdown,
     testthat,
     raster,
-    rgdal,
-    httr
+    rgdal
 VignetteBuilder: knitr
 Depends: 
     R (>= 2.10)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Suggests:
     rmarkdown,
     testthat,
     raster,
-    rgdal
+    rgdal,
+    curl
 VignetteBuilder: knitr
 Depends: 
     R (>= 2.10)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Suggests:
     testthat,
     raster,
     rgdal,
-    curl
+    httr
 VignetteBuilder: knitr
 Depends: 
     R (>= 2.10)

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -222,7 +222,6 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
   stopifnot(is.logical(force))
   stopifnot(length(pkg_dir) == 1)
   stopifnot(is.character(pkg_dir))
-  stopifnot(dir.exists(pkg_dir))
   
   # Check for binary file in 'WBT' directory
   exe_path <- wbt_default_path()
@@ -267,7 +266,8 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
     }
 
     if (requireNamespace("curl")) {
-      curl::curl_download(url = url, destfile = exe_zip)
+      curl::curl_download(url = url, destfile = exe_zip, handle = curl::new_handle(timeout_ms = 300000,
+                                                                                   timeout = 300))
     } else {
       # stop('Please install the `curl` package.\n\tinstall.packages("curl")', call. = FALSE)
       options(timeout = max(300, getOption("timeout")))

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -268,7 +268,7 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
     if (requireNamespace("curl")) {
       h <- curl::new_handle()
       curl::handle_setopt(h, timeout_ms = 300000L)
-      curl::curl_download(url = url, destfile = exe_zip, handle = )
+      curl::curl_download(url = url, destfile = exe_zip, handle = h)
     } else {
       # stop('Please install the `curl` package.\n\tinstall.packages("curl")', call. = FALSE)
       options(timeout = max(300, getOption("timeout")))

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -266,8 +266,10 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
     }
 
     if (requireNamespace("curl")) {
-      curl::curl_download(url = url, destfile = exe_zip, handle = curl::new_handle(timeout_ms = 300000,
-                                                                                   timeout = 300))
+      h <- curl::new_handle()
+      curl::handle_setopt(h, timeout_ms = 300000)
+      curl::handle_setopt(h, timeout = 300)
+      curl::curl_download(url = url, destfile = exe_zip, handle = )
     } else {
       # stop('Please install the `curl` package.\n\tinstall.packages("curl")', call. = FALSE)
       options(timeout = max(300, getOption("timeout")))
@@ -284,12 +286,12 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
     #   utils::untar(exe_zip, exdir = pkg_dir)
     # }
 
-    cat("WhiteboxTools binary is located at: ", exe_path, "\n")
+    cat("WhiteboxTools binary is located here: ", exe_path, "\n")
     cat("You can now start using whitebox\n")
     cat("    library(whitebox)\n")
     cat("    wbt_version()\n")
   } else if (!force) {
-    cat("WhiteboxTools found at path: ", exe_path, "\n")
+    cat("WhiteboxTools binary is located here: ", exe_path, "\n")
   }
   
   # return installed path

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -265,37 +265,22 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
       dir.create(pkg_dir, recursive = TRUE)
     }
 
-    # # if (requireNamespace("curl")) {
-    # #   h <- curl::new_handle()
-    # #   curl::handle_setopt(h, timeout = 300)
-    # #   curl::curl_download(url = url, destfile = exe_zip, handle = h)
-    # options(timeout = max(300, getOption("timeout")))
-    # if (requireNamespace("httr")) {
-    #   httr::GET(
-    #     url = url,
-    #     httr::write_disk(exe_zip, overwrite = TRUE),
-    #     config = httr::config(timeout_ms = 99999)
-    #   )
-    # } else {
-    #   # stop('Please install the `curl` package.\n\tinstall.packages("curl")', call. = FALSE)
-    #   options(download.file.method="libcurl", url.method="libcurl")
-    #   utils::download.file(url = url, destfile = exe_zip)
-    # }
-    
+    # this fails on some platforms and with certain URLs
+    #  tried curl::curl_download, httr::GET, and other download.file method options for libcurl
     # logic from xfun::download_file used for tinytex::install_tinytex()
     if (getOption("timeout") == 60L) {
       opts = options(timeout = 3600)
       on.exit(options(opts), add = TRUE)
     }
     res <- -1
-    .download <- function(method = "auto") download.file(url, exe_zip, method = method)
     for (method in c(if (os == "Windows") "wininet", "libcurl", "auto")) {
-      if (!inherits(try(res <- .download(method = method), silent = TRUE), "try-error") && res == 0)
+      if (!inherits(try(res <- utils::download.file(url, exe_zip, method = method), silent = TRUE), 
+                    "try-error") && res == 0)
         break
     }
     
     if (res != 0) {
-      message("Unable to download by any method! Try downloading manually from (https://www.whiteboxgeo.com/download-whiteboxtools/) unpacking to a directory and setting path with wbt_init(exe_path = '/path/to/whitebox_tools')")
+      message("Unable to download by any method! Try downloading ZIP manually from https://www.whiteboxgeo.com/download-whiteboxtools/. Installation involves just extracting to your desired directory. Set path to binary with wbt_init(exe_path = '/path/to/whitebox_tools')")
       return(invisible(NULL))
     }
     

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -270,7 +270,11 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
     #   curl::handle_setopt(h, timeout = 300)
     #   curl::curl_download(url = url, destfile = exe_zip, handle = h)
     if (requireNamespace("httr")) {
-      httr::GET(url = url, httr::write_disk(exe_zip, overwrite = TRUE))
+      httr::GET(
+        url = url,
+        httr::write_disk(exe_zip, overwrite = TRUE),
+        config = httr::config(timeout_ms = 99999)
+      )
     } else {
       # stop('Please install the `curl` package.\n\tinstall.packages("curl")', call. = FALSE)
       options(timeout = max(300, getOption("timeout")))

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -265,10 +265,12 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
       dir.create(pkg_dir, recursive = TRUE)
     }
 
-    if (requireNamespace("curl")) {
-      h <- curl::new_handle()
-      curl::handle_setopt(h, timeout_ms = 300000L)
-      curl::curl_download(url = url, destfile = exe_zip, handle = h)
+    # if (requireNamespace("curl")) {
+    #   h <- curl::new_handle()
+    #   curl::handle_setopt(h, timeout = 300)
+    #   curl::curl_download(url = url, destfile = exe_zip, handle = h)
+    if (requireNamespace("httr")) {
+      httr::GET(url = url, httr::write_disk(exe_zip, overwrite = TRUE))
     } else {
       # stop('Please install the `curl` package.\n\tinstall.packages("curl")', call. = FALSE)
       options(timeout = max(300, getOption("timeout")))

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -267,8 +267,7 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
 
     if (requireNamespace("curl")) {
       h <- curl::new_handle()
-      curl::handle_setopt(h, timeout_ms = 300000)
-      curl::handle_setopt(h, timeout = 300)
+      curl::handle_setopt(h, timeout_ms = 300000L)
       curl::curl_download(url = url, destfile = exe_zip, handle = )
     } else {
       # stop('Please install the `curl` package.\n\tinstall.packages("curl")', call. = FALSE)

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -282,19 +282,20 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
     #   utils::download.file(url = url, destfile = exe_zip)
     # }
     
-    # based on xfun::download_file used for tinytex::install_tinytex()
+    # logic from xfun::download_file used for tinytex::install_tinytex()
     if (getOption("timeout") == 60L) {
       opts = options(timeout = 3600)
       on.exit(options(opts), add = TRUE)
     }
+    res <- -1
     .download <- function(method = "auto") download.file(url, exe_zip, method = method)
     for (method in c(if (os == "Windows") "wininet", "libcurl", "auto")) {
-      if (!inherits(try(res <- .download(method = method), silent = TRUE), "try-error") && res == 0) 
-        return(res)
+      if (!inherits(try(res <- .download(method = method), silent = TRUE), "try-error") && res == 0)
+        break
     }
     
     if (res != 0) {
-      message("Unable to download by any method! Try downloading manually from https://www.whiteboxgeo.com/download-whiteboxtools/, unpacking to a directory and setting path with wbt_init(exe_path = '/path/to/whitebox_tools')")
+      message("Unable to download by any method! Try downloading manually from (https://www.whiteboxgeo.com/download-whiteboxtools/) unpacking to a directory and setting path with wbt_init(exe_path = '/path/to/whitebox_tools')")
       return(invisible(NULL))
     }
     

--- a/man/install_whitebox.Rd
+++ b/man/install_whitebox.Rd
@@ -5,10 +5,12 @@
 \alias{wbt_install}
 \title{Download and Install WhiteboxTools}
 \usage{
-install_whitebox(pkg_dir = find.package("whitebox"))
+install_whitebox(pkg_dir = find.package("whitebox"), force = FALSE)
 }
 \arguments{
 \item{pkg_dir}{default install path is to whitebox package "WBT" folder}
+
+\item{force}{logical. Default \code{FALSE}. Force install?}
 }
 \value{
 Prints out the location of the WhiteboxTools binary, if found. \code{NULL} otherwise.


### PR DESCRIPTION
 - ~Try using `curl::curl_download()` if available~ didn't work
 - ~Try using `httr::GET()`~ didn't work
 - Borrowed logic from `xfun::download_file()` used by `tinytex::install_tinytex()`
   - This does not resolve the download issue on windows, but it no longer throws an error so the CI will pass. This means that until/if this is resolved the Windows download will always be running without the exectuable. 
   - The ability to throw an error from `utils::download.file()` here is something I should have addressed in CRAN preparation as all functions that access web resources should fail gracefully. Even though we will not test `install_whitebox()` on CRAN servers it should still adhere to that idea  
 
Enhancements (the result of needing to test this over and over)
 - Add "force" argument
 - Made sure installs to arbitrary paths work  if EXE is already in package directory

Creating draft PR against `develop` branch to trigger CI