### PR TITLE
wbt_install: remove downloaded zip file when exiting function

### DIFF
--- a/R/wbt.R
+++ b/R/wbt.R
@@ -455,7 +455,10 @@ wbt_install <- function(pkg_dir = find.package("whitebox"), force = FALSE) {
     cat("\t", url, "\n")
     cat("(This could take a few minutes, please be patient...)\n")
 
+    # path for downloaded zip file;
+    # remove downloaded zip file when exiting function
     exe_zip <- file.path(pkg_dir, filename)
+    on.exit(unlink(exe_zip), add = TRUE)
 
     if (!dir.exists(pkg_dir)) {
       dir.create(pkg_dir, recursive = TRUE)


### PR DESCRIPTION
Hi, 

thanks for this great package and the whiteboxtools to use for geospatial analysis.

We bake the whiteboxtools into some docker images (which we use for CI/CD stuff etc.), installing the whiteboxtools not into the R package itself but to some other location (/usr/local/bin)

We think that after installation (or failure during the `wbt_install`), the downloaded zip file could be deleted from that location (to keep things tidy).

Happy to discuss and contribute.

Cheers, Christoph