### PR TITLE
New default value passed to `--listtools`

### DIFF
--- a/R/wbt.R
+++ b/R/wbt.R
@@ -590,7 +590,7 @@ wbt_version <- function() {
 
 #' All available tools in WhiteboxTools
 #'
-#' @param keywords Keywords may be used to search available tools.
+#' @param keywords Keywords may be used to search available tools. Default `''` returns all available tools.
 #'
 #' @return Return all available tools in WhiteboxTools that contain the keywords.
 #' @export
@@ -599,7 +599,7 @@ wbt_version <- function() {
 #' \dontrun{
 #' wbt_list_tools("lidar")
 #' }
-wbt_list_tools <- function(keywords = NULL) {
+wbt_list_tools <- function(keywords = "''") {
   ret <- wbt_system_call(paste("--listtools", keywords))
   ret <- ret[ret != ""]
   if (wbt_verbose()) {

--- a/man/wbt_list_tools.Rd
+++ b/man/wbt_list_tools.Rd
@@ -4,10 +4,10 @@
 \alias{wbt_list_tools}
 \title{All available tools in WhiteboxTools}
 \usage{
-wbt_list_tools(keywords = NULL)
+wbt_list_tools(keywords = "")
 }
 \arguments{
-\item{keywords}{Keywords may be used to search available tools.}
+\item{keywords}{Keywords may be used to search available tools. Default \code{''} returns all available tools.}
 }
 \value{
 Return all available tools in WhiteboxTools that contain the keywords.


### PR DESCRIPTION
 New default `keywords` argument to` wbt_list_tools()`  `"''"` returns all available tools on all platforms.

 Using `NULL` results in the following on Windows
 ```
> print(wbt_list_tools())
All 0 Tools containing keywords:
[1] "All 0 Tools containing keywords:"
```
Thanks to @wiesehahn for reporting the  issue.